### PR TITLE
Add OpenAI responses via RecallIO summaries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 TELEGRAM_TOKEN=your-telegram-token
 RECALLIO_API_KEY=your-recallio-api-key
 RECALLIO_PROJECT_ID=your-project-id
+OPENAI_API_KEY=your-openai-key

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This project implements a simple Telegram bot that stores user messages as memor
 - Node.js 20+
 - A Telegram bot token
 - A RecallIO API key and project ID
+- An OpenAI API key
 
 ## Setup
 
@@ -20,8 +21,8 @@ This project implements a simple Telegram bot that stores user messages as memor
 
    ```bash
    cp .env.example .env
-   # Edit .env and set TELEGRAM_TOKEN, RECALLIO_API_KEY and RECALLIO_PROJECT_ID
-   ```
+   # Edit .env and set TELEGRAM_TOKEN, RECALLIO_API_KEY, RECALLIO_PROJECT_ID and OPENAI_API_KEY
+  ```
 
 ## Build
 
@@ -41,4 +42,4 @@ After building, start the bot with:
 npm start
 ```
 
-The bot will store every non-command message as a memory and will respond to `/recall <query>` with the best matching memory content.
+The bot stores each message and answer as memories. When you send a normal message it will summarize relevant memories, call OpenAI to generate a reply, and then store both your request and the answer. Use `/recall <query>` to search your memories directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "dotenv": "^16.3.1",
         "node-telegram-bot-api": "^0.61.0",
+        "openai": "^5.8.2",
         "recallio": "^1.0.0"
       },
       "devDependencies": {
@@ -1501,6 +1502,27 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-5.8.2.tgz",
+      "integrity": "sha512-8C+nzoHYgyYOXhHGN6r0fcb4SznuEn1R7YZMvlqDbnCuE0FM2mm3T1HiYW6WIcMS/F1Of2up/cSPjLPaWt0X9Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.23.8"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/own-keys": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "dotenv": "^16.3.1",
     "node-telegram-bot-api": "^0.61.0",
+    "openai": "^5.8.2",
     "recallio": "^1.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,22 @@
 import dotenv from 'dotenv';
 import TelegramBot from 'node-telegram-bot-api';
 import { RecallioClient } from 'recallio';
+import OpenAI from 'openai';
 
 dotenv.config();
 
 const token = process.env.TELEGRAM_TOKEN;
 const recallApiKey = process.env.RECALLIO_API_KEY;
 const projectId = process.env.RECALLIO_PROJECT_ID;
+const openaiApiKey = process.env.OPENAI_API_KEY;
 
-if (!token || !recallApiKey || !projectId) {
-  throw new Error('TELEGRAM_TOKEN, RECALLIO_API_KEY and RECALLIO_PROJECT_ID must be set');
+if (!token || !recallApiKey || !projectId || !openaiApiKey) {
+  throw new Error('TELEGRAM_TOKEN, RECALLIO_API_KEY, RECALLIO_PROJECT_ID and OPENAI_API_KEY must be set');
 }
 
 const bot = new TelegramBot(token, { polling: true });
 const recallClient = new RecallioClient({ apiKey: recallApiKey });
+const openai = new OpenAI({ apiKey: openaiApiKey });
 
 bot.on('message', async (msg) => {
   const chatId = msg.chat.id;
@@ -41,18 +44,50 @@ bot.on('message', async (msg) => {
     return;
   }
 
-  // ignore bot commands
+  // ignore other bot commands
   if (text.startsWith('/')) return;
 
   try {
+    const recallResult = await recallClient.recallMemory({
+      userId,
+      projectId,
+      query: text,
+      scope: 'user',
+      summarized: true
+    });
+    const summary = (recallResult && recallResult.content) || '';
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        { role: 'system', content: `Relevant history: ${summary}` },
+        { role: 'user', content: text }
+      ]
+    });
+
+    const answer = completion.choices[0]?.message?.content?.trim() || '';
+    if (answer) {
+      await bot.sendMessage(chatId, answer);
+    }
+
+    // store request and answer as memories
     await recallClient.writeMemory({
       userId,
       projectId,
       content: text,
       consentFlag: true
     });
+    if (answer) {
+      await recallClient.writeMemory({
+        userId,
+        projectId,
+        content: answer,
+        consentFlag: true
+      });
+    }
   } catch (err) {
-    console.error('Failed to store memory', err);
+    console.error('Failed to process message', err);
+    await bot.sendMessage(chatId, 'Failed to process your message.');
   }
 });
 


### PR DESCRIPTION
## Summary
- include OPENAI API key in `.env.example`
- document new OpenAI requirement in README
- install `openai` library
- summarize memories and fetch OpenAI answers

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864053eac9c832e844f6bed12ac69ea