### PR TITLE
Update recallio usage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "dotenv": "^16.3.1",
         "node-telegram-bot-api": "^0.61.0",
         "openai": "^5.8.2",
-        "recallio": "^1.1.1"
+        "recallio": "^1.1.2"
       },
       "devDependencies": {
         "@types/node": "^24.0.8",
@@ -1631,9 +1631,10 @@
       "license": "MIT"
     },
     "node_modules/recallio": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/recallio/-/recallio-1.1.1.tgz",
-      "integrity": "sha512-ILfO8G/JiQDMPR9K5/PsHTgdkRiyf7SKqPyN8xS1nFYZykkxSqpGozDofL/c41w+SsHPr8XlUqj6FJ9Te8XvMQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/recallio/-/recallio-1.1.2.tgz",
+      "integrity": "sha512-+Zk0hTk7smCxWarrnYRlfI2DU2rxT8+/WVVW4IIyr81DR/fDpoeaMKB/kxK/50sLihfoH8KnV/6kDrCeNUXQtg==",
+      "license": "MIT",
       "dependencies": {
         "axios": "^1.7.7"
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "dotenv": "^16.3.1",
     "node-telegram-bot-api": "^0.61.0",
     "openai": "^5.8.2",
-    "recallio": "^1.1.1"
+    "recallio": "^1.1.2"
   },
   "devDependencies": {
     "@types/node": "^24.0.8",


### PR DESCRIPTION
## Summary
- upgrade recallio to 1.1.2
- use `MemoryRecallRequest` type when recalling memories
- enable re-ranking and fetch fact memories
- return all recalled facts and include them when building prompts

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c56a3100c832e89f0f5475e49032b